### PR TITLE
feat: Support query_string array type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A CLI tool To query CloudWatch Logs Insights.
 
 ![usage2](https://raw.githubusercontent.com/homoluctus/pyinsights/master/images/usage2.png)
 
-# ToC
+**ToC**
 
 <!-- TOC depthFrom:2 -->
 
@@ -18,6 +18,13 @@ A CLI tool To query CloudWatch Logs Insights.
   - [Write Configuration](#write-configuration)
   - [Execute command](#execute-command)
 - [Configuration](#configuration)
+  - [version](#version)
+  - [log_group_name](#log_group_name)
+  - [query_string](#query_string)
+  - [duration](#duration)
+    - [type: string](#type-string)
+    - [type: object](#type-object)
+  - [limit](#limit)
 - [CLI Options](#cli-options)
 - [Environment Variable](#environment-variable)
 
@@ -48,15 +55,92 @@ pyinsights -c pyinsights.yml -p aws_profile -r region
 
 ## Configuration
 
-|Parameter|Type|Required|Description|
-|:--:|:--:|:--:|:--|
-|version|string|true|Choose configuration version from ['1.0']|
-|log_group_name|array|true|Target log group names to query|
-|query_string|string|true|Pattern to query|
-|duration|string or object|true||
-||string||Specify hours, minutes or seconds from now<br>Unit:<br>hours = `h`,<br>minutes = `m`,<br>seconds = `s`,<br>days = `d`,<br>weeks = `w`|
-||object||Specify `start_time` and `end_time`<br>Datetime format must be `YYYY-MM-DD HH:MM:SS`|
-|limit|integer|false|The number of log to fetch|
+### version
+
+|Type|Required|
+|:--:|:--:|
+|string|true|
+
+Choose configuration version from ['1.0']
+
+### log_group_name
+
+|Type|Required|
+|:--:|:--:|
+|array|true|
+
+Target log group names to query
+
+### query_string
+
+|Type|Required|
+|:--:|:--:|
+|string or array|true|
+
+Specify CloudWatch Logs Insights query commands.
+Please see [CloudWatch Logs Insights Query Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html).
+
+:warning: If query_string type is array, Unix-style pipe `|` is not required. Execute in order from the top.
+
+ex)
+
+```yml
+query_string:
+  - 'field @message'
+  - 'fileter @message like /WARN/'
+```
+
+Equal to
+
+```yml
+query_string: 'field @message | fileter @message like /WARN/'
+```
+
+### duration
+
+|Type|Required|
+|:--:|:--:|
+|string or object|true|
+
+#### type: string
+
+Specify weeks, days, hours, minutes or seconds unit.
+
+```
+weeks = w
+days = d
+hours = h
+minutes = m
+seconds = s
+```
+
+ex)
+
+```yml
+duration: 10h
+```
+
+#### type: object
+
+Specify `start_time` and `end_time`.
+The format must be `YYYY-MM-DD HH:MM:SS`.
+
+ex)
+
+```yml
+duration:
+  start_time: '2020-01-01 00:00:00'
+  end_time: '2020-01-01 01:00:00'
+```
+
+### limit
+
+|Type|Required|
+|:--:|:--:|
+|integer|false|
+
+The number of log to fetch.
+Of course, you can specify `limit` in [query_string](#query_string).
 
 ## CLI Options
 

--- a/pyinsights/exceptions.py
+++ b/pyinsights/exceptions.py
@@ -36,3 +36,7 @@ class InvalidVersionError(Exception):
 
 class InvalidDurationError(Exception):
     """Raises error if the duration parameter is not number"""
+
+
+class InvalidQueryStringError(Exception):
+    """Raises error if query string format is invalid"""

--- a/pyinsights/schema/version_1.0.json
+++ b/pyinsights/schema/version_1.0.json
@@ -17,7 +17,20 @@
       },
       "query_string": {
         "description": "The query string to insights CloudWatch Logs.",
-        "type": "string"
+        "oneOf": [
+          {
+            "description": "Include pipe",
+            "type": "string"
+          },
+          {
+            "description": "Not include pipe",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        ]
       },
       "duration": {
         "oneOf": [

--- a/tests/fixtures/correct/config1.yml
+++ b/tests/fixtures/correct/config1.yml
@@ -1,0 +1,6 @@
+version: '1.0'
+log_group_name:
+  - '/ecs/sample'
+query_string: 'parse @message /time:(?<time>.*)\tseverity:(?<severity>.*)\tmodule:(?<module>.*)\tlineno:(?<lineno>\d+)\tmessage:(?<msg>.*)/'
+duration: '30m'
+limit: 10

--- a/tests/fixtures/correct/config2.yml
+++ b/tests/fixtures/correct/config2.yml
@@ -1,0 +1,9 @@
+version: '1.0'
+log_group_name:
+  - '/ecs/sample'
+  - '/lambda/sample'
+query_string: 'field @message | fileter @message like /WARN/'
+duration:
+  start_time: '2019-12-27 00:00:00'
+  end_time: '2019-12-27 01:00:00'
+limit: 10

--- a/tests/fixtures/correct/config3.yml
+++ b/tests/fixtures/correct/config3.yml
@@ -1,0 +1,11 @@
+version: '1.0'
+log_group_name:
+  - '/ecs/sample'
+  - '/lambda/sample'
+query_string:
+  - 'field @message'
+  - 'fileter @message like /WARN/'
+duration:
+  start_time: '2019-12-27 00:00:00'
+  end_time: '2019-12-27 01:00:00'
+limit: 10

--- a/tests/fixtures/invalid/additional_property.yml
+++ b/tests/fixtures/invalid/additional_property.yml
@@ -1,0 +1,7 @@
+version: '1.0'
+log_group_name:
+  - '/ecs/sample'
+query_string: 'parse @message /time:(?<time>.*)\tseverity:(?<severity>.*)\tmodule:(?<module>.*)\tlineno:(?<lineno>\d+)\tmessage:(?<msg>.*)/'
+duration: '30m'
+limit: 10
+test: 'additional property'

--- a/tests/fixtures/invalid/query_string1.yml
+++ b/tests/fixtures/invalid/query_string1.yml
@@ -1,0 +1,8 @@
+version: '1.0'
+log_group_name:
+  - '/ecs/sample'
+query_string:
+  - 'field @message '
+  - '| fileter @message like /WARN/'
+duration: '30m'
+limit: 10

--- a/tests/fixtures/invalid/query_string2.yml
+++ b/tests/fixtures/invalid/query_string2.yml
@@ -1,0 +1,8 @@
+version: '1.0'
+log_group_name:
+  - '/ecs/sample'
+query_string:
+  - 'field @message |'
+  - 'fileter @message like /WARN/'
+duration: '30m'
+limit: 10

--- a/tests/fixtures/invalid/version.yml
+++ b/tests/fixtures/invalid/version.yml
@@ -1,0 +1,7 @@
+# version is invalid
+version: 'invalid'
+log_group_name:
+  - '/ecs/sample'
+query_string: 'parse @message /time:(?<time>.*)\tseverity:(?<severity>.*)\tmodule:(?<module>.*)\tlineno:(?<lineno>\d+)\tmessage:(?<msg>.*)/'
+duration: '30m'
+limit: 10


### PR DESCRIPTION
Rows may be shorter due to support for query_string array type.
And no need Unix-style pipe `|` to separate more query commands like below.

```yml
query_string:
  - 'field @message'
  - 'fileter @message like /WARN/'
```
