### PR TITLE
fix: poetry publish use username and password instead of api token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,9 @@ jobs:
 
       - name: Release
         env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.pyinsights_uploader }}
-        run: make release
+          POETRY_USERNAME: ${{ secrets.POETRY_USERNAME }}
+          POETRY_PASSWORD: ${{ secrets.POETRY_PASSWORD }}
+        run: make release username=$POETRY_USERNAME password=$POETRY_PASSWORD
 
   github:
     name: Release to GitHub

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ mypy:
 
 .PHONY: release
 release:
-	poetry publish -n --build --username homoluctus
+	poetry publish -n --build -u $(username) -p $(password)


### PR DESCRIPTION
Reason
- Invalid authentication error occurred using api token